### PR TITLE
Fixing image lists when creating a bucket

### DIFF
--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -418,7 +418,7 @@ class BucketManager():
         
         for x in self.valid_cores:
             if docker_image == x['version']:
-                image = 'docker.io/%s/%s:%s' % (x['org'],x['repo'],x['version'])
+                image = '%s/%s:%s' % (x['org'],x['repo'],x['version'])
                 break
 
         self.buckets[ind]['docker']['image'] = image
@@ -642,7 +642,7 @@ class DockerHelper():
             create_kwargs['volumes'][key] = temp
 
         # check if we have image, if not, pull it
-        reps = ['docker.io/'+item for x in self.docker.images.list() for item in x.attrs['RepoTags']] # flat list
+        reps = [item for x in self.docker.images.list() for item in x.tags] # flat list
 
         if not image_name in reps:
             print("Pulling image: %s" % image_name)

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -642,7 +642,8 @@ class DockerHelper():
             create_kwargs['volumes'][key] = temp
 
         # check if we have image, if not, pull it
-        reps = [x.attrs['RepoTags'] for x in self.docker.images.list()]
+        reps = ['docker.io/'+item for x in self.docker.images.list() for item in x.attrs['RepoTags']] # flat list
+
         if not image_name in reps:
             print("Pulling image: %s" % image_name)
             print("   This may take some time...")


### PR DESCRIPTION
When creating a new bucket the list of available images has been flatten
and added a 'docker.io' prefix to match the image_name. When the image
already exists it will not be pulled again. Also, if using a local image
it will not be pulled, because it will show up in the docker images
list.