### PR TITLE
[ENH]: Set pulled image tag

### DIFF
--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -662,7 +662,10 @@ class DockerHelper():
         if image_id not in local_image_ids:
             print("Pulling image: %s" % image_name)
             print("   This may take some time...")
-            self.docker.images.pull(pull_image)
+            image = self.docker.images.pull(pull_image)
+            repo,digest = pull_image.split('@')
+            # When pulling from repodigest sha256 no tag is assigned. So:
+            image.tag(repo, tag=image_name)
             print("Done!")
 
         container_id = self.docker.containers.create(image_id,**create_kwargs)


### PR DESCRIPTION
When pulling an image using the repo digest sha256 a tag is not assigned on the image. The list of images shows 2019.1.0rc1 as:
```
REPOSITORY                  TAG                    IMAGE ID            CREATED             SIZE
earthcubeingeo/resen-core   <none>                 ac8e2819e502        2 weeks ago         8.92GB
```
This PR does a change in Resen.py so that after the image is pulled it is tagged so that it is listed as:
```
REPOSITORY                  TAG                    IMAGE ID            CREATED             SIZE
earthcubeingeo/resen-core   2019.1.0rc1            ac8e2819e502        2 weeks ago         8.92GB
```