### PR TITLE
Showing progress bar when pulling the resen-core image

### DIFF
--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -662,7 +662,10 @@ class DockerHelper():
         if image_id not in local_image_ids:
             print("Pulling image: %s" % image_name)
             print("   This may take some time...")
-            self.docker.images.pull(pull_image)
+            image = self.docker.images.pull(pull_image)
+            repo,digest = pull_image.split('@')
+            # When pulling from repodigest sha256 no tag is assigned. So:
+            image.tag(repo, tag=image_name)
             print("Done!")
 
         container_id = self.docker.containers.create(image_id,**create_kwargs)


### PR DESCRIPTION
Pulling an image for the first time can take several minutes. This PR adds progress bars to the images being pulled by using the [docker low-level API pull](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.image.ImageApiMixin.pull) with `stream=True`
The output is similar to:
```
Pulling image: 2019.1.0rc1
   This may take some time...

5ac827d588be [==================================================>]  424.3kB/424.3kB
d8d7747a335e [==================================================>]     663B/663B
d44ea0cd796c [==================================================>]  16.82MB/16.82MB
08790511e3e9 [==================================================>]  5.645kB/5.645kB
e3c68aea9a5f [==================================================>]     151B/151B
0448c1360cb9 [==================================================>]  14.23kB/14.23kB
484c6d5fc38a [==================================================>]  63.92MB/63.92MB
...
Done!
[resen] >>>
```