### PR TITLE
[ENH]: Progress bar when pulling images

### DIFF
--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -662,7 +662,10 @@ class DockerHelper():
         if image_id not in local_image_ids:
             print("Pulling image: %s" % image_name)
             print("   This may take some time...")
-            self.docker.images.pull(pull_image)
+            image = self.docker.images.pull(pull_image)
+            repo,digest = pull_image.split('@')
+            # When pulling from repodigest sha256 no tag is assigned. So:
+            image.tag(repo, tag=image_name)
             print("Done!")
 
         container_id = self.docker.containers.create(image_id,**create_kwargs)


### PR DESCRIPTION
Adding a one line progress bar when pulling the resen-core image for the first time. The code uses the [docker low-level API pull](https://docker-py.readthedocs.io/en/stable/api.html#docker.api.image.ImageApiMixin.pull) with `stream=True` Similar to #19 but the output is just one line.
```
Pulling image: 2019.1.0rc1
   This may take some time...
[=============>                                     ] 27.51 %, 0.429/1.56GB Elapsed time: 0:01:24
```
