### PR TITLE
[ENH]: Change uid and gid permissions on bucket creation

### DIFF
--- a/resen/resencmd.py
+++ b/resen/resencmd.py
@@ -118,10 +118,7 @@ create_bucket bucket_name : Create a new bucket with name bucket_name. Must star
         if success:
             print("Bucket created successfully!")
             if start:
-                # start bucket
-                status = self.program.start_bucket(bucket_name)
-                if not status:
-                    return
+                # bucket should already be running
                 # start jupyterlab
                 print("...starting jupyterlab...")
                 status = self.program.start_jupyter(bucket_name,local_port,container_port,lab=True)

--- a/resen/resencmd.py
+++ b/resen/resencmd.py
@@ -47,6 +47,13 @@ create_bucket bucket_name : Create a new bucket with name bucket_name. Must star
             print("Syntax Error. Usage: create_bucket bucket_name")
             return
 
+        # check if creating bucket with name bucket_name is possible:
+        print("Creating bucket with name: %s" % bucket_name)
+        status = self.program.create_bucket(bucket_name)
+        if not status:
+            print("Failed to create bucket!")
+            return
+
         # First, ask user about the bucket they want to create
         # resen-core version?
         valid_versions = sorted([x['version'] for x in self.program.bucket_manager.valid_cores])
@@ -92,13 +99,6 @@ create_bucket bucket_name : Create a new bucket with name bucket_name. Must star
         valid_inputs = ['y','n']
         msg = '>>> Start bucket and jupyterlab? (y/n): '
         start = self.get_valid_input(msg,valid_inputs) == 'y'
-
-        # Now that we have the bucket creation recipe, let's actually create it.
-        print("Creating bucket with name: %s" % bucket_name)
-        status = self.program.create_bucket(bucket_name)
-        if not status:
-            print("Failed to create bucket!")
-            return
 
         success = True
         print("...adding core...")


### PR DESCRIPTION
As per #13, on some systems, the UID and GID of user directories on the host are not the same as the default in the resen-core image. This PR executes `/usr/local/bin/start.sh` with the `NB_UID` and `NB_GID` environment variables set.

The side effect of doing this is that it takes a little while for all of the files in `/home/jovyan` to change permissions, but this will get better once https://github.com/EarthCubeInGeo/resen-core/issues/19 is implemented.

To test this, just create a new bucket. Then in jupyterlab, open terminal and execute the `top` command. You will probably see a `chmod` command running, unless you happen to have the same uid and gid as is default for the jovyan user in the container.

Please merged PR #27 before merging this one.