### PR TITLE
Fixed the port allocation bug

### DIFF
--- a/resen/resencmd.py
+++ b/resen/resencmd.py
@@ -376,7 +376,7 @@ stop_jupyter bucket_name : Stop jupyter on bucket bucket_name."""
     def get_port(self):
         # this is not atomic, so it is possible that another process might snatch up the port
         port = 9000
-        assigned_ports = [x['docker']['port'][0] for x in self.program.bucket_manager.buckets if len(x['docker']['port'])]
+        assigned_ports = [x['docker']['port'][0][0] for x in self.program.bucket_manager.buckets if len(x['docker']['port'])]
         while True:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 assigned = s.connect_ex(('localhost', port)) == 0

--- a/resen/resencmd.py
+++ b/resen/resencmd.py
@@ -376,7 +376,8 @@ stop_jupyter bucket_name : Stop jupyter on bucket bucket_name."""
     def get_port(self):
         # this is not atomic, so it is possible that another process might snatch up the port
         port = 9000
-        assigned_ports = [x['docker']['port'][0][0] for x in self.program.bucket_manager.buckets if len(x['docker']['port'])]
+        assigned_ports = [y[0] for x in self.program.bucket_manager.buckets for y in x['docker']['port']]
+
         while True:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
                 assigned = s.connect_ex(('localhost', port)) == 0


### PR DESCRIPTION
This PR includes a very simple bug fix to #38.

**IMPORTANT:** The way the list of allocated ports are formed will ONLY work if each bucket only has one port allocated.  Do we want to support buckets with multiple ports somehow in the future?  It's fairly straightforward to modify how the list of allocated ports is generated to allow this.