### PR TITLE
Bugfix export filename

### DIFF
--- a/docs/installation/installation.general.rst
+++ b/docs/installation/installation.general.rst
@@ -11,10 +11,10 @@ Python (https://www.python.org/) is an open source, interpreted programming lang
 Docker
 ======
 
-Docker CE is the recomended version of Docker to use with Resen.  `Installation instructions <https://docs.docker.com/install/>`_ can be found in the docker documentation.  Please read installation instructions carefully! For convenience, some OS specific links are provided below:
+Docker CE is the recommended version of Docker to use with Resen.  `Installation instructions <https://docs.docker.com/install/>`_ can be found in the docker documentation.  Please read installation instructions carefully! For convenience, some OS specific links are provided below:
 
 | **MacOS**: `Install Docker Desktop for Mac <https://docs.docker.com/docker-for-mac/install/>`_
-| Important! Docker Desktop is only for MacOS 10.10 Yosemite and later.  Earlier versions of MacOS should install `Docker Toolbox <https://docs.docker.com/toolbox/toolbox_install_mac/>`_.
+| Important! Docker Desktop only supports the latest two versions of MacOS.  Earlier versions of MacOS should install `Docker Toolbox <https://docs.docker.com/toolbox/toolbox_install_mac/>`_.
 
 | **Windows**: `Install Docker Desktop for Windows <https://docs.docker.com/docker-for-windows/install/>`_
 | Important! If you are already using virtualbox, do NOT install Docker Desktop.  Instead, install `Docker Toolbox <https://docs.docker.com/toolbox/toolbox_install_windows/>`_.
@@ -34,4 +34,3 @@ Resen
 Install Resen from a python 3 environment using ``pip``::
 
     pip install git+https://github.com/EarthCubeInGeo/resen.git@v2019.1.0
-

--- a/docs/installation/installation.general.rst
+++ b/docs/installation/installation.general.rst
@@ -33,4 +33,4 @@ Resen
 
 Install Resen from a python 3 environment using ``pip``::
 
-    pip install git+https://github.com/EarthCubeInGeo/resen.git@v2019.1.0
+    pip install git+https://github.com/EarthCubeInGeo/resen.git@v2019.1.1

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -902,8 +902,7 @@ class Resen():
 
     def __get_win_vbox_map(self):
         # quick fix for determining windows with docker tool box
-        # if platform.system().startswith('Win'):
-        if True:
+        if platform.system().startswith('Win'):
             print('If your are unsure of the appropriate responses below, please refer to the Resen documentation (https://resen.readthedocs.io/en/latest/installation/installation.windows.html#docker) for more details and assistance.')
             rsp = input('Resen appears to be running on a Windows system.  Are you using Docker Toolbox? (y/n): ')
             if rsp == 'y':

--- a/resen/resencmd.py
+++ b/resen/resencmd.py
@@ -190,7 +190,7 @@ export bucket_name: Export bucket to a sharable *.tar file."""
 
         bucket_name = inputs[0]
 
-        file_name = self.get_valid_local_path('>>> Enter name for output tgz file: ', is_file=True)
+        file_name = self.get_valid_local_path('>>> Enter name for output tar file: ', pathtype='potfile')
 
         print('By default, the output image will be named "{}" and tagged "latest".'.format(bucket_name.lower()))
         rsp = self.get_yn(">>> Would you like to change the name and tag? (y/n): ")

--- a/resen/resencmd.py
+++ b/resen/resencmd.py
@@ -227,16 +227,17 @@ export bucket_name: Export bucket to a sharable *.tar file."""
         required = max(report['container']*3., output*2.)
 
         print('This export could require up to %s MB of disk space to complete and will produce an output file up to %s MB.' % (int(required), int(output)))
-        # msg = '>>> Are you sure you would like to continue? (y/n): '
         rsp = self.get_yn('>>> Are you sure you would like to continue? (y/n): ')
-
-
-        try:
-            print('Exporting bucket %s.  This will take several mintues.' % bucket_name)
-            self.program.export_bucket(bucket_name, file_name, exclude_mounts=exclude_list, img_repo=img_name, img_tag=img_tag)
-        except (ValueError, RuntimeError) as e:
-            print(e)
+        if rsp == 'n':
+            print('Export bucket canceled!')
             return
+        else:
+            try:
+                print('Exporting bucket %s.  This will take several mintues.' % bucket_name)
+                self.program.export_bucket(bucket_name, file_name, exclude_mounts=exclude_list, img_repo=img_name, img_tag=img_tag)
+            except (ValueError, RuntimeError) as e:
+                print(e)
+                return
 
 
     def do_import(self,args):


### PR DESCRIPTION
This corrects a number of minor bugs:
1. The export function had an outdated keyword, which caused export to crash.
2. Entering `n` at the end of the export prompt now actually cancels the export.
3. Starting virtual box prompt now only shows up on windows machines.
4. The requirements for Docker Desktop have been corrected in the documentation.
5. The version number in the pip install instructions has been updated.
This should not majorly change any behavior, just fix a few things that slipped through the cracks.  After this PR, we can re-release version 2019.1.1.