### PR TITLE
[ENH]: Retrieve core list from resen-core repo

### DIFF
--- a/cores.json
+++ b/cores.json
@@ -1,0 +1,1 @@
+[{"version":"2019.1.0","repo":"resen-core","org":"earthcubeingeo","image_id":"sha256:5300c6652851f35d2fabf866491143f471a7e121998fba27a8dff6b3c064af35","repodigest":"sha256:a8ff4a65aa6fee6b63f52290c661501f6de5bf4c1f05202ac8823583eaad4296"}]

--- a/cores.json
+++ b/cores.json
@@ -1,1 +1,0 @@
-[{"version":"2019.1.0","repo":"resen-core","org":"earthcubeingeo","image_id":"sha256:5300c6652851f35d2fabf866491143f471a7e121998fba27a8dff6b3c064af35","repodigest":"sha256:a8ff4a65aa6fee6b63f52290c661501f6de5bf4c1f05202ac8823583eaad4296"}]

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -831,11 +831,16 @@ class Resen():
 
 
     def __get_valid_cores(self):
-        # TODO: download json file from resen-core github repo
-        #       and if that fails, fallback to hardcoded list
-        return [{"version":"2019.1.0","repo":"resen-core","org":"earthcubeingeo",
-                 "image_id":'sha256:5300c6652851f35d2fabf866491143f471a7e121998fba27a8dff6b3c064af35',
-                 "repodigest":'sha256:a8ff4a65aa6fee6b63f52290c661501f6de5bf4c1f05202ac8823583eaad4296'},]
+
+        # define core list file name
+        core_list = os.path.join(self.resen_root_dir,'cores.json')
+
+        # check if buckets.json exists, if not, initialize empty dictionary
+        with open(core_list,'r') as f:
+            cores = json.load(f)
+
+        return cores
+
 
 
     def _get_config_dir(self):

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -42,6 +42,7 @@ import webbrowser  # use this to open web browser
 from pathlib import Path            # used to check whitelist paths
 from subprocess import Popen, PIPE  # used for selinux detection
 import platform   # NEEDED FOR WINDOWS QUICK FIX
+import requests
 
 
 from .DockerHelper import DockerHelper
@@ -53,6 +54,7 @@ class Resen():
         # get configuration info
         self.resen_root_dir = self._get_config_dir()
         self.resen_home_dir = self._get_home_dir()
+
 
         # set lock
         self.__locked = False
@@ -70,7 +72,7 @@ class Resen():
         self.win_vbox_map = self.__get_win_vbox_map()
 
         ### NOTE - Does this still need to include '/home/jovyan/work' for server compatability?
-        ### If so, can we move the white list to resencmd.py? The server shouldn't every try to
+        ### If so, can we move the white list to resencmd.py? The server shouldn't ever try to
         ### mount to an illegal location but the user might.
         self.storage_whitelist = ['/home/jovyan/mount']
 
@@ -832,15 +834,30 @@ class Resen():
 
     def __get_valid_cores(self):
 
-        # define core list file name
-        core_list = os.path.join(self.resen_root_dir,'cores.json')
+        # define core list directory
+        core_dir = os.path.join(self.resen_root_dir,'cores')
 
-        # check if buckets.json exists, if not, initialize empty dictionary
-        with open(core_list,'r') as f:
-            cores = json.load(f)
+        # If core directory does not exist, create it and download the default core list file
+        if not os.path.exists(core_dir):
+            os.makedirs(core_dir)
+            self._update_core_list()
+
+        # for each JSON file in core directory, read in list of cores
+        cores = []
+        for fn in os.listdir(core_dir):
+            with open(os.path.join(core_dir,fn),'r') as f:
+                cores.extend(json.load(f))
 
         return cores
 
+    def _update_core_list(self):
+
+        core_list_url = 'https://raw.githubusercontent.com/EarthCubeInGeo/resen-core/master/cores.json'
+        core_filename = os.path.join(self.resen_root_dir,'cores','cores.json')
+
+        r = requests.get(core_list_url)
+        with open(core_filename, 'wb') as f:
+            f.write(r.content)
 
 
     def _get_config_dir(self):

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -832,25 +832,7 @@ class Resen():
             self.save_config()
 
 
-    def __get_valid_cores(self):
-
-        # define core list directory
-        core_dir = os.path.join(self.resen_root_dir,'cores')
-
-        # If core directory does not exist, create it and download the default core list file
-        if not os.path.exists(core_dir):
-            os.makedirs(core_dir)
-            self._update_core_list()
-
-        # for each JSON file in core directory, read in list of cores
-        cores = []
-        for fn in os.listdir(core_dir):
-            with open(os.path.join(core_dir,fn),'r') as f:
-                cores.extend(json.load(f))
-
-        return cores
-
-    def _update_core_list(self):
+    def update_core_list(self):
 
         core_list_url = 'https://raw.githubusercontent.com/EarthCubeInGeo/resen-core/master/cores.json'
         core_filename = os.path.join(self.resen_root_dir,'cores','cores.json')
@@ -859,6 +841,24 @@ class Resen():
         with open(core_filename, 'wb') as f:
             f.write(r.content)
 
+
+    def __get_valid_cores(self):
+
+        # define core list directory
+        core_dir = os.path.join(self.resen_root_dir,'cores')
+
+        # If core directory does not exist, create it and download the default core list file
+        if not os.path.exists(core_dir):
+            os.makedirs(core_dir)
+            self.update_core_list()
+
+        # for each JSON file in core directory, read in list of cores
+        cores = []
+        for fn in os.listdir(core_dir):
+            with open(os.path.join(core_dir,fn),'r') as f:
+                cores.extend(json.load(f))
+
+        return cores
 
     def _get_config_dir(self):
         appname = 'resen'

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -856,8 +856,11 @@ class Resen():
         # for each JSON file in core directory, read in list of cores
         cores = []
         for fn in os.listdir(core_dir):
-            with open(os.path.join(core_dir,fn),'r') as f:
-                cores.extend(json.load(f))
+            try:
+                with open(os.path.join(core_dir,fn),'r') as f:
+                    cores.extend(json.load(f))
+            except json.decoder.JSONDecodeError:
+                print('WARNING: {} is not a valid JSON file! Skiping this file.'.format(fn))
 
         return cores
 

--- a/resen/resencmd.py
+++ b/resen/resencmd.py
@@ -328,6 +328,9 @@ import : Import a bucket from a .tgz file by providing input."""
             print("Deleting %s as requested." % str(file_name))
             os.remove(file_name)
 
+    def do_update(self,arg):
+        """update : Update default list of resen-cores available."""
+        self.program.update_core_list()
 
     def do_quit(self,arg):
         """quit : Terminates the application."""

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
-import os
 
 here = path.abspath(path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,15 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
+import os
 
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
+
+
 
 setup(
     name='resen',


### PR DESCRIPTION
This PR modifies how resen gets its list of valid cores.  Instead of the hard-coded list, resen now downloads [cores.json](https://github.com/EarthCubeInGeo/resen-core/blob/master/cores.json) from the [resen-core](https://github.com/EarthCubeInGeo/resen-core) repo if there isn't already a list of cores available.  Lists of cores are contained in `~/.config/resen/cores`.  All files in this directory will be read and appended together to form the core list, so this technically sets up structure for users to add their own cores by adding their own file (say `my_cores.json`) to `~/.config/resen/cores`.  Additionally, this PR adds the `update` command, which lets users manually update the core list if we release a new core without reinstalling resen.  This PR should take care of some of the background work required for #64.  