### PR TITLE
[BUGFIX]: Better lockfile logic

### DIFF
--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -895,13 +895,31 @@ class Resen():
         return os.path.join(homedir,appname)
 
 
+    def __process_exists(self,pid):
+        try:
+            os.kill(pid,0)
+        except ProcessLookupError:
+            return False
+        return True
+
+
     def __lock(self):
+        # dev note: if we want to be more advanced, need psutil as dependency
+        # get some telemetry to fingerprint with
+        cur_pid = os.getpid()      # process id
+
+        # check if lockfile exists
         self.__lockfile = os.path.join(self.resen_root_dir,'lock')
         if os.path.exists(self.__lockfile):
-            raise RuntimeError('Another instance of Resen is already running!')
+            #parse existing file
+            with open(self.__lockfile,'r') as f:
+                pid = int(f.read())
+                if self.__process_exists(pid):
+                    raise RuntimeError('Another instance of Resen is already running!')
 
+        telem = '%d' % (cur_pid)
         with open(self.__lockfile,'w') as f:
-            f.write('locked')
+            f.write(telem)
         self.__locked = True
 
 


### PR DESCRIPTION
This PR fixes #14.

I've tested it in both Fedora 31 python3.7 and Windows 10, both OSes using python3.7.

To test:
1) install the version of resen in this branch (`fix_lockfile`)
2) open 2 terminals and try to import the `Resen` class in each. One should succeed and one should fail.
3) now close the terminal window in which importing resen succeeded. This will kill everything without cleaning up the lockfile (check that the lock file is still there). Finally, try to import the `Resen` class again and it should succeed.
