### PR TITLE
[ENH]: Generalizing to work for jupyterlab >= 3

### DIFF
--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -571,9 +571,10 @@ class Resen():
 
         # form python command to stop jupyter and execute it
         port = bucket['jupyter']['port']
-        python_cmd = 'from notebook.notebookapp import shutdown_server, list_running_servers; '
-        python_cmd += 'svrs = [x for x in list_running_servers() if x[\\\"port\\\"] == %s]; ' % (port)
-        python_cmd += 'sts = True if len(svrs) == 0 else shutdown_server(svrs[0]); print(sts)'
+        python_cmd = 'exec(\\\"try:  from jupyter_server.serverapp import shutdown_server, list_running_servers\\n'
+        python_cmd += 'except:  from notebook.notebookapp import shutdown_server, list_running_servers\\n'
+        python_cmd += 'svrs = [x for x in list_running_servers() if x[\\\\\\"port\\\\\\"] == %s]; ' % (port)
+        python_cmd += 'sts = True if len(svrs) == 0 else shutdown_server(svrs[0]); print(sts)\\\")'
         command = "bash -cl '%s/bin/python -c \"%s \"'" % (envpath,python_cmd)
         status = self.execute_command(bucket_name,command,detach=False)
 


### PR DESCRIPTION
As of Jupyterlab 3, the code necessary to shutdown a jupyterlab server moved from the `notebook` package into `jupyter_server`.

This PR generalizes the `stop_jupyter` function so that it works for jupyterlab>=3


To test this:
1. fire up a test bucket with one of the old versions of resen-core
2. test starting and stopping the bucket with `start <bucketname>` and `stop <bucketname>`
3. start up the bucket and within it, run `pip install jupyterlab==3.0.16`
4. in resen try to `stop <bucketname>` again and it will fail without this PR


This PR is required (and we'll have to release a new version of resen afterwards) for us to release the 2021.1.0 version of resen-core.