### PR TITLE
Searching only *.json files to address issue #89 and #78

### DIFF
--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -854,7 +854,6 @@ class Resen():
 
 
     def __get_valid_cores(self):
-
         # define core list directory
         core_dir = os.path.join(self.resen_root_dir,'cores')
 
@@ -864,12 +863,10 @@ class Resen():
             self.update_core_list()
 
         # for each JSON file in core directory, read in list of cores
-        cores = []
-
         json_files = glob.glob(os.path.join(core_dir, '*.json'))
 
+        cores = []
         for filename in sorted(json_files):
-
             try:
                 with open(filename) as f:
                     cores.extend(json.load(f))

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -43,6 +43,7 @@ from pathlib import Path            # used to check whitelist paths
 from subprocess import Popen, PIPE  # used for selinux detection
 import platform   # NEEDED FOR WINDOWS QUICK FIX
 import requests
+import glob
 
 
 from .DockerHelper import DockerHelper
@@ -853,7 +854,6 @@ class Resen():
 
 
     def __get_valid_cores(self):
-        import glob
 
         # define core list directory
         core_dir = os.path.join(self.resen_root_dir,'cores')
@@ -867,15 +867,14 @@ class Resen():
         cores = []
 
         json_files = glob.glob(os.path.join(core_dir, '*.json'))
-        JSON_files = glob.glob(os.path.join(core_dir, '*.JSON'))
 
-        for filename in json_files + JSON_files:
+        for filename in json_files:
 
             try:
                 with open(filename) as f:
                     cores.extend(json.load(f))
             except:
-                print('WARNING: Problem reading {filename} . Skipping.'.format(filename=filename))
+                print(f'WARNING: Problem reading {filename} . Skipping.')
 
         return cores
 

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -864,6 +864,10 @@ class Resen():
         # for each JSON file in core directory, read in list of cores
         cores = []
         for fn in os.listdir(core_dir):
+
+            if os.path.splitext(fn)[-1].upper() != '.JSON':
+                continue # discard files that don't have the json extension
+
             try:
                 with open(os.path.join(core_dir,fn),'r') as f:
                     cores.extend(json.load(f))

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -853,6 +853,8 @@ class Resen():
 
 
     def __get_valid_cores(self):
+        import glob
+
         # define core list directory
         core_dir = os.path.join(self.resen_root_dir,'cores')
 
@@ -863,10 +865,7 @@ class Resen():
 
         # for each JSON file in core directory, read in list of cores
         cores = []
-        for fn in os.listdir(core_dir):
-
-            if not fn.lower().endswith('json'):
-                continue # discard files that don't have the json extension
+        for fn in glob.glob1(core_dir,"*.[jJ][sS][oO][nN]"):
 
             try:
                 with open(os.path.join(core_dir,fn),'r') as f:

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -865,7 +865,7 @@ class Resen():
         cores = []
         for fn in os.listdir(core_dir):
 
-            if os.path.splitext(fn)[-1].upper() != '.JSON':
+            if not fn.lower().endswith('json'):
                 continue # discard files that don't have the json extension
 
             try:

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -865,15 +865,17 @@ class Resen():
 
         # for each JSON file in core directory, read in list of cores
         cores = []
-        for fn in glob.glob1(core_dir,"*.[jJ][sS][oO][nN]"):
+
+        json_files = glob.glob(os.path.join(core_dir, '*.json'))
+        JSON_files = glob.glob(os.path.join(core_dir, '*.JSON'))
+
+        for filename in json_files + JSON_files:
 
             try:
-                with open(os.path.join(core_dir,fn),'r') as f:
+                with open(filename) as f:
                     cores.extend(json.load(f))
-            except json.decoder.JSONDecodeError:
-                print('WARNING: {} is not a valid JSON file! Skipping this file.'.format(fn))
             except:
-                print('WARNING: {} can not be read. Skipping this file.'.format(fn))
+                print('WARNING: Problem reading {filename} . Skipping.'.format(filename=filename))
 
         return cores
 

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -868,7 +868,7 @@ class Resen():
 
         json_files = glob.glob(os.path.join(core_dir, '*.json'))
 
-        for filename in json_files:
+        for filename in sorted(json_files):
 
             try:
                 with open(filename) as f:

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -874,7 +874,7 @@ class Resen():
                 with open(filename) as f:
                     cores.extend(json.load(f))
             except:
-                print(f'WARNING: Problem reading {filename} . Skipping.')
+                print(f'WARNING: Problem reading {filename}. Skipping.')
 
         return cores
 

--- a/resen/Resen.py
+++ b/resen/Resen.py
@@ -868,7 +868,9 @@ class Resen():
                 with open(os.path.join(core_dir,fn),'r') as f:
                     cores.extend(json.load(f))
             except json.decoder.JSONDecodeError:
-                print('WARNING: {} is not a valid JSON file! Skiping this file.'.format(fn))
+                print('WARNING: {} is not a valid JSON file! Skipping this file.'.format(fn))
+            except:
+                print('WARNING: {} can not be read. Skipping this file.'.format(fn))
 
         return cores
 


### PR DESCRIPTION
This adds a general exception to handle possible file problems in the files used for specifying `resen-core` images inside folder ~/.config/resen/cores. The issue is reported in #78 and in #89 
As an example, one of those problems arose when a file was opened with the `vim` editor which creates a swap file with non-utf-8 characters in it which caused `resen` to crash at the start. With this fix, a warning is issued about the file that couldn't be read and `resen` start with no problems.