### PR TITLE
Set up automatic publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,34 @@
+# This workflow will build the distribution and publish it to PyPI
+# Based on: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Publish resen to PyPI
+
+on: push
+# on:
+#   release:
+#     types: [published]
+
+
+jobs:
+  build-n-publish:
+    name: Build and publish distribution to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install pypa/build
+        run: |
+          python -m pip install build --user
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -m build --sdist --wheel --outdir dist/
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          # password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,10 +3,10 @@
 
 name: Publish resen to PyPI
 
-on: push
-# on:
-#   release:
-#     types: [published]
+# on: push
+on:
+  release:
+    types: [published]
 
 
 jobs:
@@ -29,6 +29,6 @@ jobs:
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
-          # password: ${{ secrets.PYPI_API_TOKEN }}
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          # password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          # repository_url: https://test.pypi.org/legacy/

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Resen requires both python 3 and docker to be installed.
 2. Install `docker <https://docs.docker.com/install/>`_
 3. Install Resen with pip ``pip install git+https://github.com/EarthCubeInGeo/resen.git@v2021.1.0``
 
-Please refer to the :ref:`installation documentation <installation>` for more detailed instructions.
+Please refer to the `installation documentation <installation>` for more detailed instructions.
 
 Usage
 -----
@@ -32,7 +32,7 @@ For a list of available commands, use the ``help`` command::
 
 	[resen] >>> help
 
-:ref:`Resen Workflow Example <resen-workflow>`
+`Resen Workflow Example <resen-workflow>`
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Resen requires both python 3 and docker to be installed.
 2. Install `docker <https://docs.docker.com/install/>`_
 3. Install Resen with pip ``pip install resen``
 
-Please refer to the `installation documentation <https://resen.readthedocs.io/en/latest/installation/index.html>` for more detailed instructions.
+Please refer to the `installation documentation <https://resen.readthedocs.io/en/latest/installation/index.html>`_ for more detailed instructions.
 
 Usage
 -----
@@ -32,7 +32,7 @@ For a list of available commands, use the ``help`` command::
 
 	[resen] >>> help
 
-`Resen Workflow Example <https://resen.readthedocs.io/en/latest/usage.html#resen-workflow>`
+`Resen Workflow Example <https://resen.readthedocs.io/en/latest/usage.html#resen-workflow>`_
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -37,3 +37,5 @@ For a list of available commands, use the ``help`` command::
 Documentation
 =============
 Complete documentation for Resen is available at https://resen.readthedocs.io/.
+
+small change 1

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,9 @@ Resen requires both python 3 and docker to be installed.
 
 1. Install `Python 3 <https://www.python.org/>`_
 2. Install `docker <https://docs.docker.com/install/>`_
-3. Install Resen with pip ``pip install git+https://github.com/EarthCubeInGeo/resen.git@v2021.1.0``
+3. Install Resen with pip ``pip install resen``
 
-Please refer to the `installation documentation <installation>` for more detailed instructions.
+Please refer to the `installation documentation <https://resen.readthedocs.io/en/latest/installation/index.html>` for more detailed instructions.
 
 Usage
 -----
@@ -32,10 +32,8 @@ For a list of available commands, use the ``help`` command::
 
 	[resen] >>> help
 
-`Resen Workflow Example <resen-workflow>`
+`Resen Workflow Example <https://resen.readthedocs.io/en/latest/usage.html#resen-workflow>`
 
 Documentation
 =============
 Complete documentation for Resen is available at https://resen.readthedocs.io/.
-
-small change 1

--- a/docs/version_update.py
+++ b/docs/version_update.py
@@ -4,7 +4,7 @@ import re
 import os
 import fileinput
 
-old_version = '2020.2.0'
+old_version = '2021.1.0a'
 new_version = '2021.1.0'
 
 for root, dirs, files in os.walk('..'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/resen/__init__.py
+++ b/resen/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2021.1.0c'
+__version__ = '2021.1.0'
 
 from .Resen import Resen

--- a/resen/__init__.py
+++ b/resen/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2021.1.0b'
+__version__ = '2021.1.0c'
 
 from .Resen import Resen

--- a/resen/__init__.py
+++ b/resen/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2021.1.0'
+__version__ = '2021.1.0a'
 
 from .Resen import Resen

--- a/resen/__init__.py
+++ b/resen/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '2021.1.0a'
+__version__ = '2021.1.0b'
 
 from .Resen import Resen

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'Topic :: Software Development',
 
         # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: GPLv3 License',
+        'License :: OSI Approved :: GNU General Public License (GPL)',
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.


### PR DESCRIPTION
This PR adds the pyproject.toml file, which defines how the distribution should be built, and the publish-to-pypi.yml file, which defines the github action to automatically publish new releases to PyPI.  The latest release has been manually added to PyPI and should now be available. 

https://pypi.org/project/resen/ 